### PR TITLE
fix: add AKS and OT to codespell ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,4 @@ ignore = ["E501"]
 
 [tool.codespell]
 skip = "venv,site,.git,*.png,*.jpg,*.svg,*.ico,requirements-lock.txt"
-ignore-words-list = "ciso,cosckoya"
+ignore-words-list = "ciso,cosckoya,aks,ot"


### PR DESCRIPTION
## Summary

- `AKS` (Azure Kubernetes Service) and `OT` (Operational Technology) were flagged by codespell as misspellings
- Both are valid technical acronyms used throughout the docs
- Added to `ignore-words-list` in `pyproject.toml`

## Test plan

- [x] `codespell docs/ --skip="*.png,*.jpg,*.svg,*.ico" --ignore-words-list="ciso,cosckoya,aks,ot"` — clean locally
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)