### PR TITLE
docs: #59 - create CLAUDE.md with project commands and conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md
+
+## Project
+
+MkDocs Material documentation site at cosckoya.github.io
+
+## Commands
+
+- `source venv/bin/activate && mkdocs serve` — Dev server with live reload at localhost:8000
+- `source venv/bin/activate && mkdocs build --strict` — Validate (warnings = errors)
+- `make validate` — Same as strict build
+- `make lint` — ruff + codespell + yamllint (non-blocking)
+- `make health` — Run health check script
+
+## Conventions
+
+- FontAwesome icons only (`:fontawesome-solid-...:`), no emojis
+- 3-tab Quick Hits structure (Essential / Common Patterns / Pro Tips & Gotchas)
+- Vibe Check footer on every content page
+- Tags at bottom of page (not in frontmatter)
+- Literate-nav with SUMMARY.md files for navigation
+- Templates in `docs/templates/page.template.md`


### PR DESCRIPTION
Closes #59

**Cambios:**
- Creación de CLAUDE.md en raíz del repo
- Contiene: Project, Commands, Conventions
- Claude Code ya puede leerlo como source of truth

**Verificación:**
- [x] CLAUDE.md existe en raíz
- [x] Contiene commands y conventions
- [x] mkdocs build --strict pasa