### PR TITLE
chore: #62 - pin all dev tool dependencies to exact versions

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,4 +1,4 @@
-babel==2.18.0
+babel==2.17.0
 backrefs==6.1
 bandit==1.9.4
 cairocffi==1.7.1
@@ -6,10 +6,11 @@ CairoSVG==2.9.0
 certifi==2026.1.4
 cffi==2.0.0
 cfgv==3.5.0
-charset-normalizer==3.4.7
+charset-normalizer==3.4.4
 click==8.3.1
 codespell==2.4.2
 colorama==0.4.6
+-e git+https://github.com/cosckoya/cosckoya.github.io.git@cdceab1bb49bf895915eea985dc60b7c53632768#egg=cosckoya_docs
 csscompressor==0.9.5
 cssselect2==0.9.0
 defusedxml==0.7.1
@@ -22,7 +23,7 @@ identify==2.6.15
 idna==3.15
 Jinja2==3.1.6
 jsmin==3.0.1
-Markdown==3.10.2
+Markdown==3.10.1
 markdown-it-py==3.0.0
 MarkupSafe==3.0.3
 mdformat==0.7.22
@@ -35,21 +36,22 @@ mdit-py-plugins==0.5.0
 mdurl==0.1.2
 mergedeep==1.3.4
 mkdocs==1.6.1
-mkdocs-get-deps==0.2.2
+mkdocs-get-deps==0.2.0
 mkdocs-literate-nav==0.6.3
 mkdocs-material==9.7.6
 mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.8.0
 mkdocs-same-dir==0.1.5
 mkdocs-section-index==0.3.12
-more-itertools==11.1.0
+more-itertools==10.8.0
 nodeenv==1.10.0
 packaging==26.0
 paginate==0.5.7
-pathspec==1.1.1
+pathspec==1.0.4
 pillow==12.2.0
 platformdirs==4.5.1
 pre_commit==4.6.0
+properdocs==1.6.7
 pycparser==3.0
 Pygments==2.20.0
 pymdown-extensions==10.21.3
@@ -59,9 +61,9 @@ PyYAML==6.0.3
 pyyaml_env_tag==1.1
 regex==2025.11.3
 requests==2.33.0
-rich==15.0.0
+rich==14.3.1
 ruamel.yaml==0.19.1
-ruff==0.15.15
+ruff==0.15.16
 setuptools==80.9.0
 six==1.17.0
 stevedore==5.6.0
@@ -69,7 +71,7 @@ tinycss2==1.5.1
 urllib3==2.7.0
 virtualenv==21.4.0
 watchdog==6.0.0
-wcwidth==0.7.0
+wcwidth==0.2.14
 webencodings==0.5.1
 wheel==0.47.0
 yamllint==1.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # MkDocs Material Documentation Site - Core Dependencies
-# Updated: 2026-05-09
-# PINNED to exact versions.
+# Updated: 2026-07-06
+# ALL dependencies pinned to exact versions for reproducible builds.
 
 # Core MkDocs
 mkdocs==1.6.1
@@ -22,17 +22,17 @@ mkdocs-section-index==0.3.12
 pillow==12.2.0                   # Image processing — 12.2.0 fixes 2 high + 3 medium CVEs
 cairosvg==2.9.0                  # SVG→PNG for social cards plugin
 
-# Development Tools (optional)
-mdformat>=0.7.22,<0.8.0
-mdformat-gfm>=0.4.1,<1.0.0
-mdformat-admon>=2.1.1,<3.0.0
-mdformat-frontmatter>=2.0.8,<3.0.0
-mdformat-mkdocs>=2.1.1,<3.0.0
-mdformat-tables>=1.0.0,<2.0.0
-codespell>=2.4.1,<3.0.0
-ruff>=0.14.14,<1.0.0
-bandit>=1.9.3,<2.0.0
-yamllint>=1.38.0,<2.0.0
+# Development Tools (pinned exact)
+mdformat==0.7.22
+mdformat-gfm==0.4.1
+mdformat-admon==2.1.1
+mdformat-frontmatter==2.1.2
+mdformat-mkdocs==2.1.1
+mdformat-tables==1.0.0
+codespell==2.4.2
+ruff==0.15.16
+bandit==1.9.4
+yamllint==1.38.0
 
-# Pre-commit (optional)
-pre-commit>=4.5.1,<5.0.0
+# Pre-commit (pinned exact)
+pre-commit==4.6.0


### PR DESCRIPTION
Closes #62

**Cambios:**
- Dev tools range pins (>=,<) → exact pins (==)
- Header actualizado: "ALL dependencies pinned to exact versions"
- requirements-lock.txt regenerado con pip freeze
- Versiones: mdformat 0.7.22, codespell 2.4.2, ruff 0.15.16, bandit 1.9.4, yamllint 1.38.0, pre-commit 4.6.0, etc.

**Verificación:**
- [x] mkdocs build --strict pasa