### PR TITLE
chore: #63 - sync pre-commit versions with CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.16
     hooks:
       - id: ruff
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args: [--skip, "*.png,*.jpg,*.svg,*.ico,venv,site,.git"]
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: [-c, .yamllint.yml]

--- a/scripts/health.py
+++ b/scripts/health.py
@@ -33,7 +33,6 @@ def main():
                 continue
             lines = content.split("\n")
             inside_code_block = False
-            placeholder_found = False
             for i, line in enumerate(lines):
                 stripped = line.strip()
                 if stripped.startswith("```"):
@@ -47,7 +46,6 @@ def main():
                     print(f"  PLACEHOLDER: {rel}:{i+1}")
                     issues += 1
                     count += 1
-                    placeholder_found = True
                     break
     if count == 0:
         print("  No unresolved placeholders found.")


### PR DESCRIPTION
Closes #63

**Cambios:**
- yamllint v1.37.1 → v1.38.0 (match CI/requirements.txt)
- ruff v0.14.14 → v0.15.16 (match requirements.txt)
- codespell v2.4.1 → v2.4.2 (match requirements.txt)
- scripts/health.py: remove unused `placeholder_found` variable (ruff F841)

**Verificación:**
- [x] pre-commit run --all-files pasa
- [x] mkdocs build --strict pasa