### PR TITLE
chore: #65 - add transitive-deps group to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Transitive dependencies (not directly managed)
+      transitive-deps:
+        patterns:
+          - "wcwidth"
+          - "filelock"
+          - "identify"
+          - "mdit-py-plugins"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Closes #65

**Cambios:**
- Add `transitive-deps` group covering: wcwidth, filelock, identify, mdit-py-plugins
- These transitive deps now bundled into a single weekly PR instead of individual PRs

**Verificación:**
- [x] yamllint pasa (solo warning pre-existente document-start)